### PR TITLE
Add Command sonic-clear logging

### DIFF
--- a/clear/main.py
+++ b/clear/main.py
@@ -569,7 +569,7 @@ def logging(all):
         files_to_delete += [f"{log_path}/syslog.1"]
 
     for f in files_to_delete:
-        cmd = ['sudo', 'rm' '-f',f]
+        cmd = ['sudo', 'rm','-f',f]
         run_command(cmd)
 
 if __name__ == '__main__':

--- a/clear/main.py
+++ b/clear/main.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import sys
 import click
+import glob
 import utilities_common.cli as clicommon
 import utilities_common.multi_asic as multi_asic_util
 from sonic_py_common.general import getstatusoutput_noshell_pipe
@@ -550,23 +551,25 @@ def route(prefix, vrf, namespace):
 helper = util_base.UtilHelper()
 helper.load_and_register_plugins(plugins, cli)
 
+@click.option('--all', '-a', is_flag=True, help='Delete also compressed logs')
 @cli.command()
-@click.option('-a','--all', is_flag=True, help='Delete also old compressed logs')
 def logging(all):
     """Clear logging files"""
     if os.path.exists("/var/log.tmpfs"):
         log_path = "/var/log.tmpfs"
     else:
         log_path = "/var/log"
+    
+    if all:
+        files_to_delete = glob.glob("{}/syslog*".format(log_path))
+    else
+        files_to_delete = glob.glob("{}/syslog".format(log_path))
+    if os.path.isfile("{}/syslog.1".format(log_path))
+        files_to_delete += glob.glob("{}/syslog.1".format(log_path))
 
-    if (all):
-        command = "sudo rm -f {}/syslog.*".format(log_path)
-    else:
-        if os.path.isfile("{}/syslog.1".format(log_path)):
-            command = "sudo rm -f  {}/syslog.1 {}/syslog".format(log_path, log_path)
-        else:
-            command = "sudo rm -f {}/syslog".format(log_path)            
-        run_command(command)
+    for f in files_to_delete:
+        cmd = ['sudo', 'rm' '-f',f]
+        run_command(cmd)
 
 if __name__ == '__main__':
     cli()

--- a/clear/main.py
+++ b/clear/main.py
@@ -551,7 +551,7 @@ helper = util_base.UtilHelper()
 helper.load_and_register_plugins(plugins, cli)
 
 @cli.command()
-@click.option('-a','--all', is_flag=True)
+@click.option('-a','--all', is_flag=True, help='Delete also old compressed logs')
 def logging(all):
     """Clear logging files"""
     if os.path.exists("/var/log.tmpfs"):
@@ -559,16 +559,13 @@ def logging(all):
     else:
         log_path = "/var/log"
 
-#delete currently active syslog files (syslog & syslog.1)        
-    if os.path.isfile("{}/syslog.1".format(log_path)):
-        command = "sudo rm -f  {}/syslog.1 {}/syslog".format(log_path, log_path)
-    else:
-        command = "sudo rm -f {}/syslog".format(log_path)            
-    run_command(command)
-
-#delete syslog stored files
     if (all):
-        command = "sudo rm -f {}/syslog.*.gz".format(log_path)
+        command = "sudo rm -f {}/syslog.*".format(log_path)
+    else:
+        if os.path.isfile("{}/syslog.1".format(log_path)):
+            command = "sudo rm -f  {}/syslog.1 {}/syslog".format(log_path, log_path)
+        else:
+            command = "sudo rm -f {}/syslog".format(log_path)            
         run_command(command)
 
 if __name__ == '__main__':

--- a/clear/main.py
+++ b/clear/main.py
@@ -551,19 +551,25 @@ helper = util_base.UtilHelper()
 helper.load_and_register_plugins(plugins, cli)
 
 @cli.command()
-def logging():
+@cli.option('-a','--all', is_flag=True)
+def logging(all):
     """Clear logging files"""
     if os.path.exists("/var/log.tmpfs"):
         log_path = "/var/log.tmpfs"
     else:
         log_path = "/var/log"
-        
+
+#delete currently active syslog files (syslog & syslog.1)        
     if os.path.isfile("{}/syslog.1".format(log_path)):
         command = "sudo rm -f  {}/syslog.1 {}/syslog".format(log_path, log_path)
     else:
-        command = "sudo rm -f {}/syslog".format(log_path)
-            
+        command = "sudo rm -f {}/syslog".format(log_path)            
     run_command(command)
+
+#delete syslog stored files
+    if (all):
+        command = "sudo rm -f {}/syslog.*.gz".format(log_path)
+        run_command(command)
 
 if __name__ == '__main__':
     cli()

--- a/clear/main.py
+++ b/clear/main.py
@@ -562,7 +562,7 @@ def logging(all):
     
     if all:
         files_to_delete = glob.glob("{}/syslog*".format(log_path))
-    else
+    else:
         files_to_delete = glob.glob("{}/syslog".format(log_path))
     if os.path.isfile("{}/syslog.1".format(log_path))
         files_to_delete += glob.glob("{}/syslog.1".format(log_path))

--- a/clear/main.py
+++ b/clear/main.py
@@ -557,7 +557,12 @@ def logging():
         log_path = "/var/log.tmpfs"
     else:
         log_path = "/var/log"
-    command = ['sudo', 'rm', '-f', '{}/syslog'.format(log_path)]    
+        
+    if os.path.isfile("{}/syslog.1".format(log_path)):
+        command = "sudo rm -f  {}/syslog.1 {}/syslog".format(log_path, log_path)
+    else:
+        command = "sudo rm -f {}/syslog".format(log_path)
+            
     run_command(command)
 
 if __name__ == '__main__':

--- a/clear/main.py
+++ b/clear/main.py
@@ -561,11 +561,12 @@ def logging(all):
         log_path = "/var/log"
     
     if all:
-        files_to_delete = glob.glob("{}/syslog*".format(log_path))
+        files_to_delete = glob.glob(f"{log_path}/syslog*")
     else:
-        files_to_delete = glob.glob("{}/syslog".format(log_path))
-    if os.path.isfile("{}/syslog.1".format(log_path)):
-        files_to_delete += glob.glob("{}/syslog.1".format(log_path))
+        files_to_delete = [f"{log_path}/syslog"]
+        
+    if os.path.isfile(f"{log_path}/syslog.1"):
+        files_to_delete += [f"{log_path}/syslog.1"]
 
     for f in files_to_delete:
         cmd = ['sudo', 'rm' '-f',f]

--- a/clear/main.py
+++ b/clear/main.py
@@ -551,7 +551,7 @@ helper = util_base.UtilHelper()
 helper.load_and_register_plugins(plugins, cli)
 
 @cli.command()
-@cli.option('-a','--all', is_flag=True)
+@click.option('-a','--all', is_flag=True)
 def logging(all):
     """Clear logging files"""
     if os.path.exists("/var/log.tmpfs"):

--- a/clear/main.py
+++ b/clear/main.py
@@ -564,7 +564,7 @@ def logging(all):
         files_to_delete = glob.glob("{}/syslog*".format(log_path))
     else:
         files_to_delete = glob.glob("{}/syslog".format(log_path))
-    if os.path.isfile("{}/syslog.1".format(log_path))
+    if os.path.isfile("{}/syslog.1".format(log_path)):
         files_to_delete += glob.glob("{}/syslog.1".format(log_path))
 
     for f in files_to_delete:

--- a/clear/main.py
+++ b/clear/main.py
@@ -550,6 +550,15 @@ def route(prefix, vrf, namespace):
 helper = util_base.UtilHelper()
 helper.load_and_register_plugins(plugins, cli)
 
+@cli.command()
+def logging():
+    """Clear logging files"""
+    if os.path.exists("/var/log.tmpfs"):
+        log_path = "/var/log.tmpfs"
+    else:
+        log_path = "/var/log"
+    command = ['sudo', 'rm', '-f', '{}/syslog'.format(log_path)]    
+    run_command(command)
 
 if __name__ == '__main__':
     cli()


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Added command 
sonic-clear logging         - delete syslog & syslog.1
sonic-clear logging -a/--all     - delete syslog* files
#### How I did it
Equivalent to "show logging" command, working on files at /var/log or at /var/log.tmpfs
delete relevant syslog* files
#### How to verify it
1. clear logging when no syslog files exist
2. clear logging when only syslog file exist
3. clear logging when syslog & syslog.1 files exits
4. clear logging when syslog, syslog.1 and syslog2.gz files exits

Repeat 1-4 with
Clear logging --all

verify also that show logging behave correctly after clear
#### Previous command output (if the output of a command-line utility has changed)
NR
#### New command output (if the output of a command-line utility has changed)
none
