### PR TITLE
Add vlan validation in config interface ip add command

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -4513,6 +4513,13 @@ def ip(ctx):
     """Set IP interface attributes"""
     pass
 
+def validate_vlan_format(text):
+    pattern = re.compile(r'^Vlan([1-9]\d{0,2}|[1-3]\d{3}|40[0-8][0-9]|409[0-4])$')
+
+    if pattern.match(text):
+        return True
+    else:
+        return False
 #
 # 'add' subcommand
 #
@@ -4544,6 +4551,7 @@ def add(ctx, interface_name, ip_addr, gw):
     if interface_is_in_portchannel(portchannel_member_table, interface_name):
         ctx.fail("{} is configured as a member of portchannel."
                 .format(interface_name))
+    
 
     try:
         ip_address = ipaddress.ip_interface(ip_addr)
@@ -4576,6 +4584,12 @@ def add(ctx, interface_name, ip_addr, gw):
     table_name = get_interface_table_name(interface_name)
     if table_name == "":
         ctx.fail("'interface_name' is not valid. Valid names [Ethernet/PortChannel/Vlan/Loopback]")
+    
+    if table_name == "VLAN_INTERFACE":
+        if not validate_vlan_format(interface_name):
+            ctx.fail(f"{interface_name} is not a valid Vlan name")
+            return
+    
     interface_entry = config_db.get_entry(table_name, interface_name)
     if len(interface_entry) == 0:
         if table_name == "VLAN_SUB_INTERFACE":

--- a/config/main.py
+++ b/config/main.py
@@ -4516,6 +4516,11 @@ def ip(ctx):
 def validate_vlan_format(text):
     pattern = re.compile(r'^Vlan([1-9]\d{0,2}|[1-3]\d{3}|40[0-8][0-9]|409[0-4])$')
     return pattern.fullmatch(text) is not None
+    
+def validate_vlan_exists(db,text):
+    data = db.get_table('VLAN')
+    keys = list(data.keys())
+    return text in keys
 #
 # 'add' subcommand
 #
@@ -4524,8 +4529,9 @@ def validate_vlan_format(text):
 @click.argument('interface_name', metavar='<interface_name>', required=True)
 @click.argument("ip_addr", metavar="<ip_addr>", required=True)
 @click.argument('gw', metavar='<default gateway IP address>', required=False)
+@click.option('-i','--ignore-vlan',is_flag=True, required=False, help="Allow configuration on not created Vlan")
 @click.pass_context
-def add(ctx, interface_name, ip_addr, gw):
+def add(ctx, interface_name, ip_addr, gw, ignore_vlan):
     """Add an IP address towards the interface"""
     # Get the config_db connector
     config_db = ValidatedConfigDBConnector(ctx.obj['config_db'])
@@ -4581,9 +4587,14 @@ def add(ctx, interface_name, ip_addr, gw):
         ctx.fail("'interface_name' is not valid. Valid names [Ethernet/PortChannel/Vlan/Loopback]")
     
     if table_name == "VLAN_INTERFACE":
-        if not validate_vlan_format(interface_name):
-            ctx.fail(f"Error: {interface_name} is not a valid Vlan name")
-            return
+        if ignore_vlan:
+            if not validate_vlan_format(interface_name):
+                ctx.fail(f"Error: {interface_name} is not a valid Vlan name")
+                return
+        else:
+            if not validate_vlan_exists(config_db, interface_name):
+                ctx.fail(f"Error: {interface_name} does not exist")
+                return
     
     interface_entry = config_db.get_entry(table_name, interface_name)
     if len(interface_entry) == 0:

--- a/config/main.py
+++ b/config/main.py
@@ -4515,11 +4515,7 @@ def ip(ctx):
 
 def validate_vlan_format(text):
     pattern = re.compile(r'^Vlan([1-9]\d{0,2}|[1-3]\d{3}|40[0-8][0-9]|409[0-4])$')
-
-    if pattern.match(text):
-        return True
-    else:
-        return False
+    return pattern.fullmatch(text) is not None
 #
 # 'add' subcommand
 #
@@ -4551,7 +4547,6 @@ def add(ctx, interface_name, ip_addr, gw):
     if interface_is_in_portchannel(portchannel_member_table, interface_name):
         ctx.fail("{} is configured as a member of portchannel."
                 .format(interface_name))
-    
 
     try:
         ip_address = ipaddress.ip_interface(ip_addr)
@@ -4587,7 +4582,7 @@ def add(ctx, interface_name, ip_addr, gw):
     
     if table_name == "VLAN_INTERFACE":
         if not validate_vlan_format(interface_name):
-            ctx.fail(f"{interface_name} is not a valid Vlan name")
+            ctx.fail(f"Error: {interface_name} is not a valid Vlan name")
             return
     
     interface_entry = config_db.get_entry(table_name, interface_name)

--- a/tests/ip_config_test.py
+++ b/tests/ip_config_test.py
@@ -13,6 +13,7 @@ from utilities_common.db import Db
 import utilities_common.bgp_util as bgp_util
 
 ERROR_MSG = "Error: IP address is not valid"
+VLAN_ERROR_MSG = "not a valid Vlan name"
 
 INVALID_VRF_MSG ="""\
 Usage: bind [OPTIONS] <interface_name> <vrf_name>
@@ -42,6 +43,40 @@ class TestConfigIP(object):
 
     def mock_run_bgp_command():
         return ""
+
+    def test_add_vlan_interface_ipv4(self):
+        db = Db()
+        runner = CliRunner()
+        obj = {'config_db':db.cfgdb}
+
+        # config int ip add Vlan100 1.1.1.1/24
+        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["add"], ["Vlan100", "1.1.1.1/24"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+
+        # config int ip add Vlan4093 1.1.1.1/24
+        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["add"], ["Vlan4093", "1.1.1.1/24"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+
+        # config int ip add Vlan000000000000003 1.1.1.1/24
+        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["add"], ["Vlan000000000000003", "1.1.1.1/24"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code != 0
+        assert VLAN_ERROR_MSG in result.output
+
+        # config int ip add Vlan01 1.1.1.1/24
+        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["add"], ["Vlan01", "1.1.1.1/24"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code != 0
+        assert VLAN_ERROR_MSG in result.output
+
+        # config int ip add Vlan1.2 1.1.1.1/24
+        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["add"], ["Vlan1.2", "1.1.1.1/24"], obj=obj)
+        print(result.exit_code, result.output)
+        assert result.exit_code != 0
+        assert VLAN_ERROR_MSG in result.output
+
 
     def test_add_del_interface_valid_ipv4(self):
         db = Db()

--- a/tests/ip_config_test.py
+++ b/tests/ip_config_test.py
@@ -13,7 +13,6 @@ from utilities_common.db import Db
 import utilities_common.bgp_util as bgp_util
 
 ERROR_MSG = "Error: IP address is not valid"
-ILLEGAL_VLAN_ERROR_MSG = "not a valid Vlan name"
 NOT_EXIST_VLAN_ERROR_MSG ="does not exist"
 
 INVALID_VRF_MSG ="""\
@@ -56,11 +55,6 @@ class TestConfigIP(object):
         assert result.exit_code != 0
         assert NOT_EXIST_VLAN_ERROR_MSG in result.output
 
-        # config int ip add Vlan101 1.1.1.1/24 --ignore-vlan
-        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["add"], [ "Vlan101", "1.1.1.1/24" , "--ignore-vlan"], obj=obj)
-        print(result.exit_code, result.output)
-        assert result.exit_code == 0
-
         # create vlan 4093
         result = runner.invoke(config.config.commands["vlan"].commands["add"], ["4093"], obj=db)
         # config int ip add Vlan4093 1.1.1.1/24
@@ -69,22 +63,16 @@ class TestConfigIP(object):
         assert result.exit_code == 0
 
         # config int ip add Vlan000000000000003 1.1.1.1/24
-        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["add"], ["Vlan000000000000003", "1.1.1.1/24" , "--ignore-vlan"], obj=obj)
-        print(result.exit_code, result.output)
-        assert result.exit_code != 0
-        assert ILLEGAL_VLAN_ERROR_MSG in result.output
-
-        # config int ip add Vlan01 1.1.1.1/24
-        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["add"], ["Vlan01", "1.1.1.1/24"], obj=obj)
+        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["add"], ["Vlan000000000000003", "1.1.1.1/24"], obj=obj)
         print(result.exit_code, result.output)
         assert result.exit_code != 0
         assert NOT_EXIST_VLAN_ERROR_MSG in result.output
 
         # config int ip add Vlan1.2 1.1.1.1/24
-        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["add"], ["Vlan1.2", "1.1.1.1/24", "--ignore-vlan"], obj=obj)
+        result = runner.invoke(config.config.commands["interface"].commands["ip"].commands["add"], ["Vlan1.2", "1.1.1.1/24"], obj=obj)
         print(result.exit_code, result.output)
         assert result.exit_code != 0
-        assert ILLEGAL_VLAN_ERROR_MSG in result.output
+        assert NOT_EXIST_VLAN_ERROR_MSG in result.output
 
 
     def test_add_del_interface_valid_ipv4(self):


### PR DESCRIPTION
~

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Fix for -16975
Prevent configuration of illegal Vlan name in "config interface ip add" command
#### How I did it
Added Vlan name validation
#### How to verify it
##### Positive tests
config interface ip add Vlan100 1.1.1.1/24
config interface ip add Vlan4093 1.1.1.1/24
##### Negative tests
config interface ip add Vlan000000000000003 1.1.1.1/24
config interface ip add Vlan01 1.1.1.1/24
config interface ip add Vlan1.2 1.1.1.1/24
#### Previous command output (if the output of a command-line utility has changed)
On illegal Vlan name command succeeded with no error
#### New command output (if the output of a command-line utility has changed)
config interface ip add Vlan030 1.1.1.1/24
Error: Vlan030 is not a valid Vlan name
